### PR TITLE
ignore error when src file goes away while copying

### DIFF
--- a/fsync.go
+++ b/fsync.go
@@ -108,6 +108,9 @@ func sync(del bool, dst, src string) {
 		panic(err)
 	}
 	s, err := os.Stat(src)
+	if err != nil && os.IsNotExist(err) {
+		return // src was deleted before we could copy it
+	}
 	check(err)
 
 	if !s.IsDir() {


### PR DESCRIPTION
this occurs when tools like emacs create lock files
these files may be present when traversal starts
but often are removed by the time the iteration reaches them
