### PR TITLE
Do not skip setting modTime after setting permission

### DIFF
--- a/fsync.go
+++ b/fsync.go
@@ -203,7 +203,6 @@ func (s *Syncer) syncstats(dst, src string) {
 	// update dst's permission bits
 	if dstat.Mode().Perm() != sstat.Mode().Perm() {
 		check(os.Chmod(dst, sstat.Mode().Perm()))
-		return
 	}
 
 	// update dst's modification time


### PR DESCRIPTION
This solves the following bug discovered by the Debian Reproducible Builds effort:

    $ umask 0002
    $ go test -v github.com/mostafah/fsync
    === RUN   TestSync
    --- FAIL: TestSync (0.00s)
        fsync_test.go:136: modification time for "dst/a/b" is 2015-11-14 12:16:50.130875985 -0700 MST, should be 2015-11-14 11:16:50.133133817 -0700 MST.
        fsync_test.go:136: modification time for "dst/c" is 2015-11-14 12:16:50.130875985 -0700 MST, should be 2015-11-14 11:16:50.133133817 -0700 MST.
    FAIL
    exit status 1
    FAIL    github.com/mostafah/fsync   0.003s

See Issue mostafah/fsync#5 for discussion.