### PR TITLE
Delete filter

### DIFF
--- a/fsync.go
+++ b/fsync.go
@@ -189,10 +189,7 @@ func (s *Syncer) sync(dst, src string) {
 		files, err = ioutil.ReadDir(dst)
 		check(err)
 		for _, file := range files {
-			if s.DeleteFilter(file) {
-				continue
-			}
-			if !m[file.Name()] {
+			if !m[file.Name()] && !s.DeleteFilter(file) {
 				check(os.RemoveAll(filepath.Join(dst, file.Name())))
 			}
 		}

--- a/fsync_test.go
+++ b/fsync_test.go
@@ -92,6 +92,46 @@ func TestSync(t *testing.T) {
 	}
 }
 
+func TestDeleteFileFilter(t *testing.T) {
+	// create test directory and chdir to it
+	dir, err := ioutil.TempDir(os.TempDir(), "fsync_test_delete_filter")
+	check(err)
+	check(os.Chdir(dir))
+
+	// create test files and directories
+	check(os.MkdirAll("src/a", 0755))
+	check(ioutil.WriteFile("src/a/b", []byte("file b"), 0644))
+
+	check(os.MkdirAll("dst", 0755))
+	check(ioutil.WriteFile("dst/c", []byte("file c"), 0644))
+	check(ioutil.WriteFile("dst/d", []byte("file c"), 0644))
+
+	// create Syncer
+	s := NewSyncer()
+	s.Delete = true
+	s.DeleteFilter = func(f os.FileInfo) bool {
+	fmt.Println(f.Name())
+	if f.Name() == "d" {
+		return true
+	}
+	return false
+	}
+
+	//precondition; dst contains 2 files `c` and `d`
+	testDirContents("dst", 2, t)
+	testExistence("dst/c", true, t)
+	testExistence("dst/d", true, t)
+
+	check(s.Sync("dst", "src"))
+
+	// check results; c should no longer exist
+	testDirContents("dst", 2, t)
+	testExistence("dst/a/", true, t)
+	testExistence("dst/a/b", true, t)
+	testExistence("dst/c", false, t)
+	testExistence("dst/d", true, t)
+}
+
 func testFile(name string, b []byte, t *testing.T) {
 	testExistence(name, true, t)
 	c, err := ioutil.ReadFile(name)


### PR DESCRIPTION
Added a filter function to allow certain files to remain in the destination dir.
If the function is not overridden the current behaviour does not change.

The change will allow this issue to be addressed: https://github.com/spf13/hugo/issues/3202